### PR TITLE
Hide table columns

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-w-[340px]`}
       >
         <MainHeader />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,8 @@ import jobs from "../utils/resume_jobs.json";
 export default function Home() {
   return (
     <div className="min-h-screen bg-[#161617] bg-cover bg-center flex flex-col">
-      <div className="h-[68px] bg-pink-600"></div>
-      <main className="grid grid-cols-1 lg:grid-cols-3 justify-center items-center flex-1 bg-yellow-600">
+      <div className="h-[68px]"></div>
+      <main className="grid grid-cols-1 lg:grid-cols-3 justify-center items-center flex-1">
         <div className="mx-5 p-8 flex flex-col text-center justify-center items-center bg-[#222223] rounded-lg border border-gray-600 shadow-[inset_4px_4px_8px_rgba(255,255,255,0.1),_inset_-4px_-4px_8px_rgba(0,0,0,0.5)]">
           <Image
             className="mb-4 rounded-2xl"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,9 +4,9 @@ import jobs from "../utils/resume_jobs.json";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-[#161617] bg-cover bg-center">
-      <div className="h-[68px]"></div>
-      <main className="grid grid-cols-1 lg:grid-cols-3 justify-center items-center">
+    <div className="min-h-screen bg-[#161617] bg-cover bg-center flex flex-col">
+      <div className="h-[68px] bg-pink-600"></div>
+      <main className="grid grid-cols-1 lg:grid-cols-3 justify-center items-center flex-1 bg-yellow-600">
         <div className="mx-5 p-8 flex flex-col text-center justify-center items-center bg-[#222223] rounded-lg border border-gray-600 shadow-[inset_4px_4px_8px_rgba(255,255,255,0.1),_inset_-4px_-4px_8px_rgba(0,0,0,0.5)]">
           <Image
             className="mb-4 rounded-2xl"

--- a/src/app/soccer-dashboard/components/StandingsTable.tsx
+++ b/src/app/soccer-dashboard/components/StandingsTable.tsx
@@ -74,15 +74,16 @@ export default function StandingsTable(props) {
   };
 
   const hideColumns = (columnId: string) => {
+    const standardCSS = "px-1 min-w-[90px] cursor-pointer";
     if (smallHiddenColumns.includes(columnId)) {
-      return "px-1 min-w-[90px] cursor-pointer hidden lg:table-cell";
+      return `${standardCSS} hidden lg:table-cell`;
     }
 
     if (mediumHiddenColumns.includes(columnId)) {
-      return "px-1 min-w-[90px] cursor-pointer hidden md:table-cell";
+      return `${standardCSS} hidden md:table-cell`;
     }
 
-    return "px-1 min-w-[90px] cursor-pointer";
+    return standardCSS;
   };
 
   const standingsTable = useReactTable({
@@ -167,7 +168,7 @@ export default function StandingsTable(props) {
             >
               {row.getVisibleCells().map((cell) => {
                 console.log(cell.column.id);
-                const rowClassName = hideColumns(cell.column.id);
+                const rowClassName = hideColumns(cell.column.id, "");
                 return (
                   <td key={cell.id} className={rowClassName}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/app/soccer-dashboard/components/StandingsTable.tsx
+++ b/src/app/soccer-dashboard/components/StandingsTable.tsx
@@ -96,13 +96,13 @@ export default function StandingsTable(props) {
   });
 
   return (
-    <table className="text-center text-base text-xs md:text-[14px] w-[340px] md:w-full lg:w-[1000px] ">
+    <table className="text-center text-base text-xs md:text-[14px] lg:text-[15px] w-[340px] md:w-full lg:w-[1000px] ">
       <caption id="table-caption" className="sr-only">
         Premier League Table displaying team positions, played games, wins,
         draws, losses, goals, and points.
       </caption>
 
-      <thead className="bg-[#2b2d42]">
+      <thead className="bg-[#2b2d42] text-[15px]">
         {standingsTable.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
             {headerGroup.headers.map((header) => {

--- a/src/app/soccer-dashboard/components/StandingsTable.tsx
+++ b/src/app/soccer-dashboard/components/StandingsTable.tsx
@@ -167,8 +167,7 @@ export default function StandingsTable(props) {
               } hover:bg-[rgba(180,200,220,0.88)] h-[25px] sm:h-[30px] cursor-default hover:cursor-pointer`}
             >
               {row.getVisibleCells().map((cell) => {
-                console.log(cell.column.id);
-                const rowClassName = hideColumns(cell.column.id, "");
+                const rowClassName = hideColumns(cell.column.id);
                 return (
                   <td key={cell.id} className={rowClassName}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/app/soccer-dashboard/components/StandingsTable.tsx
+++ b/src/app/soccer-dashboard/components/StandingsTable.tsx
@@ -50,6 +50,16 @@ export default function StandingsTable(props) {
 
   const emptyRows = 20 - rowData.length;
 
+  const hiddenColumns = [
+    "goalDifference",
+    "goalsFor",
+    "goalsAgainst",
+    "playedGames",
+    "won",
+    "draw",
+    "lost",
+  ];
+
   const handleClick = (teamName: string) => {
     router.push(`/soccer-dashboard/scoring-leaders/${slugify(teamName)}`);
   };
@@ -75,7 +85,7 @@ export default function StandingsTable(props) {
   });
 
   return (
-    <table className="text-center text-base w-[1100px]">
+    <table className="text-center text-base text-sm md:text-[1rem] w-[340px] md:w-full lg:w-[1000px] ">
       <caption id="table-caption" className="sr-only">
         Premier League Table displaying team positions, played games, wins,
         draws, losses, goals, and points.
@@ -84,69 +94,82 @@ export default function StandingsTable(props) {
       <thead className="bg-[#2b2d42]">
         {standingsTable.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <th
-                key={header.id}
-                role="columnheader"
-                scope="col"
-                tabIndex={0}
-                className="px-1 min-w-[90px] cursor-pointer"
-                onClick={header.column.getToggleSortingHandler()}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    header.column.getToggleSortingHandler()(e);
+            {headerGroup.headers.map((header) => {
+              const headerClassName = hiddenColumns.includes(header.id)
+                ? "px-1 min-w-[90px] cursor-pointer hidden lg:table-cell"
+                : "px-1 min-w-[90px] cursor-pointer";
+              return (
+                <th
+                  key={header.id}
+                  role="columnheader"
+                  scope="col"
+                  tabIndex={0}
+                  className={headerClassName}
+                  onClick={header.column.getToggleSortingHandler()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      header.column.getToggleSortingHandler()(e);
+                    }
+                  }}
+                  aria-sort={
+                    header.column.getIsSorted()
+                      ? header.column.getIsSorted() === "desc"
+                        ? "descending"
+                        : "ascending"
+                      : "none"
                   }
-                }}
-                aria-sort={
-                  header.column.getIsSorted()
-                    ? header.column.getIsSorted() === "desc"
-                      ? "descending"
-                      : "ascending"
-                    : "none"
-                }
-              >
-                {header.isPlaceholder ? null : (
-                  <div className="flex items-center justify-center gap-1">
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                    <span aria-hidden="true">
-                      {{
-                        asc: " ↑",
-                        desc: " ↓",
-                      }[header.column.getIsSorted() as string] ?? ""}
-                    </span>
-                  </div>
-                )}
-              </th>
-            ))}
+                >
+                  {header.isPlaceholder ? null : (
+                    <div className="flex items-center justify-center gap-1">
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                      <span aria-hidden="true">
+                        {{
+                          asc: " ↑",
+                          desc: " ↓",
+                        }[header.column.getIsSorted() as string] ?? ""}
+                      </span>
+                    </div>
+                  )}
+                </th>
+              );
+            })}
           </tr>
         ))}
       </thead>
 
       <tbody className="bg-[rgba(141,153,174,0.88)] ">
-        {standingsTable.getRowModel().rows.map((row, index) => (
-          <tr
-            key={row.id}
-            tabIndex={0}
-            role="row"
-            aria-label={`Row ${row.original.name} with ${row.original.points} points`}
-            onClick={() => handleClick(row.original.name)}
-            onKeyDown={(e) => handleKeyDown(e, row.original.name)}
-            className={`${
-              index % 2 === 0
-                ? "bg-[rgba(141,153,174,0.88)]"
-                : "bg-[rgba(224, 232, 235, 0.88)]"
-            } hover:bg-[rgba(180,200,220,0.88)] h-[30px] cursor-default hover:cursor-pointer`}
-          >
-            {row.getVisibleCells().map((cell) => (
-              <td key={cell.id} className="px-1">
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </td>
-            ))}
-          </tr>
-        ))}
+        {standingsTable.getRowModel().rows.map((row, index) => {
+          return (
+            <tr
+              key={row.id}
+              tabIndex={0}
+              role="row"
+              aria-label={`Row ${row.original.name} with ${row.original.points} points`}
+              onClick={() => handleClick(row.original.name)}
+              onKeyDown={(e) => handleKeyDown(e, row.original.name)}
+              className={`${
+                index % 2 === 0
+                  ? "bg-[rgba(141,153,174,0.88)]"
+                  : "bg-[rgba(224, 232, 235, 0.88)]"
+              } hover:bg-[rgba(180,200,220,0.88)] h-[30px] cursor-default hover:cursor-pointer`}
+            >
+              {row.getVisibleCells().map((cell) => {
+                console.log(cell.column.id);
+                const rowClassName = hiddenColumns.includes(cell.column.id)
+                  ? "px-1 hidden lg:table-cell"
+                  : "px-1";
+                return (
+                  <td key={cell.id} className={rowClassName}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
 
         {Array.from({ length: emptyRows }).map((_, idx) => (
           <tr

--- a/src/app/soccer-dashboard/components/StandingsTable.tsx
+++ b/src/app/soccer-dashboard/components/StandingsTable.tsx
@@ -50,15 +50,14 @@ export default function StandingsTable(props) {
 
   const emptyRows = 20 - rowData.length;
 
-  const hiddenColumns = [
+  const smallHiddenColumns = [
     "goalDifference",
     "goalsFor",
     "goalsAgainst",
     "playedGames",
-    "won",
-    "draw",
-    "lost",
   ];
+
+  const mediumHiddenColumns = ["won", "draw", "lost"];
 
   const handleClick = (teamName: string) => {
     router.push(`/soccer-dashboard/scoring-leaders/${slugify(teamName)}`);
@@ -74,6 +73,18 @@ export default function StandingsTable(props) {
     return text.replace(/\s+/g, "_");
   };
 
+  const hideColumns = (columnId: string) => {
+    if (smallHiddenColumns.includes(columnId)) {
+      return "px-1 min-w-[90px] cursor-pointer hidden lg:table-cell";
+    }
+
+    if (mediumHiddenColumns.includes(columnId)) {
+      return "px-1 min-w-[90px] cursor-pointer hidden md:table-cell";
+    }
+
+    return "px-1 min-w-[90px] cursor-pointer";
+  };
+
   const standingsTable = useReactTable({
     data: rowData,
     columns: tableHeaders,
@@ -85,7 +96,7 @@ export default function StandingsTable(props) {
   });
 
   return (
-    <table className="text-center text-base text-sm md:text-[1rem] w-[340px] md:w-full lg:w-[1000px] ">
+    <table className="text-center text-base text-xs md:text-[14px] w-[340px] md:w-full lg:w-[1000px] ">
       <caption id="table-caption" className="sr-only">
         Premier League Table displaying team positions, played games, wins,
         draws, losses, goals, and points.
@@ -95,9 +106,7 @@ export default function StandingsTable(props) {
         {standingsTable.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
             {headerGroup.headers.map((header) => {
-              const headerClassName = hiddenColumns.includes(header.id)
-                ? "px-1 min-w-[90px] cursor-pointer hidden lg:table-cell"
-                : "px-1 min-w-[90px] cursor-pointer";
+              const headerClassName = hideColumns(header.id);
               return (
                 <th
                   key={header.id}
@@ -154,13 +163,11 @@ export default function StandingsTable(props) {
                 index % 2 === 0
                   ? "bg-[rgba(141,153,174,0.88)]"
                   : "bg-[rgba(224, 232, 235, 0.88)]"
-              } hover:bg-[rgba(180,200,220,0.88)] h-[30px] cursor-default hover:cursor-pointer`}
+              } hover:bg-[rgba(180,200,220,0.88)] h-[25px] sm:h-[30px] cursor-default hover:cursor-pointer`}
             >
               {row.getVisibleCells().map((cell) => {
                 console.log(cell.column.id);
-                const rowClassName = hiddenColumns.includes(cell.column.id)
-                  ? "px-1 hidden lg:table-cell"
-                  : "px-1";
+                const rowClassName = hideColumns(cell.column.id);
                 return (
                   <td key={cell.id} className={rowClassName}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/app/soccer-dashboard/components/TopSoccerPlayersTable.tsx
+++ b/src/app/soccer-dashboard/components/TopSoccerPlayersTable.tsx
@@ -87,7 +87,7 @@ export default function TopSoccerPlayersTable(props) {
   });
 
   return (
-    <table className="text-center text-base text-[10px] md:text-[15px] w-[340px] sm:w-[400px] md:w-[550px] lg:w-[900px]">
+    <table className="text-center text-base text-[10px] md:text-[15px] lg:text-[16px]">
       <caption id="scoring-table-caption" className="sr-only">
         Scoring table displaying player information, including name, date of
         birth, nationality, position, goals, assists, and matches played.
@@ -162,18 +162,21 @@ export default function TopSoccerPlayersTable(props) {
           </tr>
         ))}
 
-        {Array.from({ length: emptyRows }).map((_, idx) => (
-          <tr
-            key={`empty-${idx}`}
-            className={`${
-              idx % 2 === 0
-                ? "bg-[rgba(141,153,174,0.88)]"
-                : "bg-[rgba(224, 232, 235, 0.88)]"
-            } hover:bg-[rgba(180,200,220,0.88)]`}
-          >
-            <td colSpan={7} className="h-[30px]"></td>
-          </tr>
-        ))}
+        {Array.from({ length: emptyRows }).map((_, idx) => {
+          const baseIndex = 12 - emptyRows;
+          return (
+            <tr
+              key={`empty-${idx + baseIndex}`}
+              className={`${
+                (baseIndex + idx) % 2 === 0
+                  ? "bg-[rgba(141,153,174,0.88)]"
+                  : "bg-[rgba(224, 232, 235, 0.88)]"
+              } hover:bg-[rgba(180,200,220,0.88)]`}
+            >
+              <td colSpan={7} className="h-[30px]"></td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/src/app/soccer-dashboard/components/TopSoccerPlayersTable.tsx
+++ b/src/app/soccer-dashboard/components/TopSoccerPlayersTable.tsx
@@ -58,6 +58,24 @@ export default function TopSoccerPlayersTable(props) {
   if (rowData?.length) {
     emptyRows = 12 - rowData.length;
   }
+
+  const smallHiddenColumns = ["dateOfBirth", "nationality"];
+
+  const mediumHiddenColumns = ["position"];
+
+  const hideColumns = (columnId: string) => {
+    const standardCSS = "px-2";
+    if (smallHiddenColumns.includes(columnId)) {
+      return `${standardCSS} hidden lg:table-cell`;
+    }
+
+    if (mediumHiddenColumns.includes(columnId)) {
+      return `${standardCSS} hidden md:table-cell`;
+    }
+
+    return standardCSS;
+  };
+
   const scoringTable = useReactTable({
     data: rowData,
     columns: tableHeaders,
@@ -69,52 +87,55 @@ export default function TopSoccerPlayersTable(props) {
   });
 
   return (
-    <table className="text-center text-base w-[820px]">
+    <table className="text-center text-base text-[10px] md:text-[15px] w-[340px] sm:w-[400px] md:w-[550px] lg:w-[900px]">
       <caption id="scoring-table-caption" className="sr-only">
         Scoring table displaying player information, including name, date of
         birth, nationality, position, goals, assists, and matches played.
       </caption>
 
-      <thead className="bg-[#2b2d42]">
+      <thead className="bg-[#2b2d42] text-[15px]">
         {scoringTable.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <th
-                key={header.id}
-                role="columnheader"
-                scope="col"
-                tabIndex={0}
-                className="px-3 min-w-[90px] cursor-pointer"
-                onClick={header.column.getToggleSortingHandler()}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    header.column.getToggleSortingHandler()(e);
+            {headerGroup.headers.map((header) => {
+              const headerClassName = hideColumns(header.id);
+              return (
+                <th
+                  key={header.id}
+                  role="columnheader"
+                  scope="col"
+                  tabIndex={0}
+                  className={headerClassName}
+                  onClick={header.column.getToggleSortingHandler()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      header.column.getToggleSortingHandler()(e);
+                    }
+                  }}
+                  aria-sort={
+                    header.column.getIsSorted()
+                      ? header.column.getIsSorted() === "desc"
+                        ? "descending"
+                        : "ascending"
+                      : "none"
                   }
-                }}
-                aria-sort={
-                  header.column.getIsSorted()
-                    ? header.column.getIsSorted() === "desc"
-                      ? "descending"
-                      : "ascending"
-                    : "none"
-                }
-              >
-                {header.isPlaceholder ? null : (
-                  <div className="flex items-center justify-center gap-1">
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                    <span aria-hidden="true">
-                      {{
-                        asc: " ↑",
-                        desc: " ↓",
-                      }[header.column.getIsSorted() as string] ?? ""}
-                    </span>
-                  </div>
-                )}
-              </th>
-            ))}
+                >
+                  {header.isPlaceholder ? null : (
+                    <div className="flex items-center justify-center gap-1">
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                      <span aria-hidden="true">
+                        {{
+                          asc: " ↑",
+                          desc: " ↓",
+                        }[header.column.getIsSorted() as string] ?? ""}
+                      </span>
+                    </div>
+                  )}
+                </th>
+              );
+            })}
           </tr>
         ))}
       </thead>
@@ -130,11 +151,14 @@ export default function TopSoccerPlayersTable(props) {
                 : "bg-[rgba(224, 232, 235, 0.88)]"
             } hover:bg-[rgba(180,200,220,0.88)] h-[30px] cursor-default`}
           >
-            {row.getVisibleCells().map((cell) => (
-              <td key={cell.id} className="px-2">
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </td>
-            ))}
+            {row.getVisibleCells().map((cell) => {
+              const rowClassName = hideColumns(cell.column.id);
+              return (
+                <td key={cell.id} className={rowClassName}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              );
+            })}
           </tr>
         ))}
 

--- a/src/app/soccer-dashboard/layout.tsx
+++ b/src/app/soccer-dashboard/layout.tsx
@@ -10,10 +10,10 @@ export default function SoccerLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <div className="bg-[url('/background_images/soccer_pitch.jpg')] bg-cover bg-center">
+    <div className="bg-[url('/background_images/soccer_pitch.jpg')] bg-cover bg-center flex flex-col">
       <div className="h-[68px]"></div>
       <main>
-        <div className="h-[calc(100vh-68px)] flex flex-col justify-center items-center -translate-y-3">
+        <div className="h-[calc(100vh-68px)] flex flex-col justify-center items-center flex-1">
           {children}
         </div>
       </main>

--- a/src/app/soccer-dashboard/page.tsx
+++ b/src/app/soccer-dashboard/page.tsx
@@ -20,7 +20,7 @@ export default function SoccerDashboard() {
             ...item,
             name: item.team.name,
           }));
-          // setRowData(extractedData);
+          setRowData(extractedData);
         }
       } catch (error) {
         console.error("Error fetching data: ", error);
@@ -31,12 +31,12 @@ export default function SoccerDashboard() {
     fetchData();
   }, []);
   return (
-    <div className="h-[80vh] flex flex-col justify-center items-center">
+    <div className="h-[80vh] flex flex-col justify-center items-center ">
       <h1 className="text-3xl md:text-4xl lg:text-5xl mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)]">
         Premier League Table
       </h1>
       {isLoading ? (
-        <div className="flex flex-col justify-center items-center h-[626px] w-[1100px] bg-[rgba(141,153,174,0.88)]">
+        <div className="flex flex-col justify-center items-center h-[626px] w-[340px] md:w-full lg:w-[1000px] bg-[rgba(141,153,174,0.88)]">
           <ScaleLoader
             data-testid="loading-spinner"
             height={80}

--- a/src/app/soccer-dashboard/page.tsx
+++ b/src/app/soccer-dashboard/page.tsx
@@ -15,6 +15,13 @@ export default function SoccerDashboard() {
         const fetchResponse = await fetch("/api/soccer-dashboard/standings");
 
         const jsonData = await fetchResponse.json();
+
+        if (jsonData.errorCode) {
+          console.error(
+            `Error fetching response ${jsonData.errorCode}: ${jsonData.message}`
+          );
+        }
+
         if (jsonData.standings) {
           const extractedData = jsonData.standings[0].table.map((item) => ({
             ...item,

--- a/src/app/soccer-dashboard/page.tsx
+++ b/src/app/soccer-dashboard/page.tsx
@@ -20,7 +20,7 @@ export default function SoccerDashboard() {
             ...item,
             name: item.team.name,
           }));
-          setRowData(extractedData);
+          // setRowData(extractedData);
         }
       } catch (error) {
         console.error("Error fetching data: ", error);
@@ -31,8 +31,8 @@ export default function SoccerDashboard() {
     fetchData();
   }, []);
   return (
-    <div className="h-screen flex flex-col justify-center items-center">
-      <h1 className="text-5xl mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)]">
+    <div className="h-[80vh] flex flex-col justify-center items-center">
+      <h1 className="text-3xl md:text-4xl lg:text-5xl mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)]">
         Premier League Table
       </h1>
       {isLoading ? (
@@ -49,7 +49,6 @@ export default function SoccerDashboard() {
           <h2 className="mt-5 text-white text-2xl font-bold">Loading...</h2>
         </div>
       ) : (
-        // <div></div>
         <StandingsTable rowData={rowData} />
       )}
     </div>

--- a/src/app/soccer-dashboard/scoring-leaders/[team_name]/page.tsx
+++ b/src/app/soccer-dashboard/scoring-leaders/[team_name]/page.tsx
@@ -64,18 +64,18 @@ export default function ScoringLeaders() {
       } catch (error) {
         console.error("Error fetching data: ", error);
       }
-      setIsLoading(false);
+      // setIsLoading(false);
     };
 
     fetchData();
   }, [desluggedTeam]);
 
   return (
-    <div className="text-5xl mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)] text-center">
+    <div className="text-2xl md:text-4xl lg:text-5xl sm:mb-4 drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)] text-center">
       <h1>{desluggedTeam}</h1>
       <h2 className="mb-5">In Top 100</h2>
       {isLoading ? (
-        <div className="flex flex-col justify-center items-center h-[386px] w-[820px] bg-[rgba(141,153,174,0.88)]">
+        <div className="flex flex-col justify-center items-center h-[386px]  w-[340px] sm:w-[400px] md:w-[550px] lg:w-[900px] bg-[rgba(141,153,174,0.88)]">
           <ScaleLoader
             data-testid="loading-spinner"
             height={50}
@@ -88,14 +88,14 @@ export default function ScoringLeaders() {
           <h2 className="mt-3 text-2xl">Loading...</h2>
         </div>
       ) : (
-        <div className="w-[1075px] flex justify-center">
+        <div className="flex justify-center">
           <TopSoccerPlayersTable rowData={rowData} />
         </div>
       )}
       <div className="mt-4">
         <button
           onClick={() => router.push("/soccer-dashboard")}
-          className="px-6 py-3 bg-[#2b2d42] text-white text-3xl rounded-lg hover:bg-gray-800"
+          className="px-6 py-3 bg-[#2b2d42] text-white text-lg sm:text-3xl rounded-lg hover:bg-gray-800"
           aria-label="Go back to the homepage"
         >
           Back to Home

--- a/src/app/soccer-dashboard/scoring-leaders/[team_name]/page.tsx
+++ b/src/app/soccer-dashboard/scoring-leaders/[team_name]/page.tsx
@@ -59,6 +59,12 @@ export default function ScoringLeaders() {
 
         const jsonData = await fetchResponse.json();
 
+        if (jsonData.errorCode) {
+          console.error(
+            `Error fetching response ${jsonData.errorCode}: ${jsonData.message}`
+          );
+        }
+
         const filteredPlayers = filterScorers(desluggedTeam, jsonData.scorers);
         setRowData(filteredPlayers);
       } catch (error) {
@@ -88,7 +94,7 @@ export default function ScoringLeaders() {
           <h2 className="mt-3 text-2xl">Loading...</h2>
         </div>
       ) : (
-        <div className="flex justify-center aspect-[16/9] bg-pink-600">
+        <div className="flex justify-center aspect-[16/9]">
           <TopSoccerPlayersTable rowData={rowData} />
         </div>
       )}

--- a/src/app/soccer-dashboard/scoring-leaders/[team_name]/page.tsx
+++ b/src/app/soccer-dashboard/scoring-leaders/[team_name]/page.tsx
@@ -64,7 +64,7 @@ export default function ScoringLeaders() {
       } catch (error) {
         console.error("Error fetching data: ", error);
       }
-      // setIsLoading(false);
+      setIsLoading(false);
     };
 
     fetchData();
@@ -88,7 +88,7 @@ export default function ScoringLeaders() {
           <h2 className="mt-3 text-2xl">Loading...</h2>
         </div>
       ) : (
-        <div className="flex justify-center">
+        <div className="flex justify-center aspect-[16/9] bg-pink-600">
           <TopSoccerPlayersTable rowData={rowData} />
         </div>
       )}


### PR DESCRIPTION
Table columns will be hidden on smaller screens to allow for a more reactive design. This will not work nicely when inverting your phone and is only meant to work vertically. 